### PR TITLE
There is no need to install squid3 anymore

### DIFF
--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,4 +1,4 @@
-You can find a config file at `/etc/__SQUID_FOLDER__/squid.conf`.
+You can find a config file at `/etc/squid/squid.conf`.
 Squid 3 will work with your registered users through LDAP. Just put the username and password when asked.
 
 To configure on Firefox go to preferences->general->network proxy->manual proxy configuration.

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,7 @@ code = "https://github.com/squid-cache/squid"
 cpe = "cpe:2.3:a:squid-cache:squid"
 
 [integration]
-yunohost = ">= 11.2"
+yunohost = ">= 12.0"
 architectures = "all"
 multi_instance = false
 
@@ -44,12 +44,4 @@ ram.runtime = "50M"
     main.exposed = "TCP"
 
     [resources.apt]
-    packages = ["mailutils"]
-
-    packages_from_raw_bash = """
-        if [[ $YNH_DEBIAN_VERSION == "bullseye" ]]; then
-            echo "squid3";
-        elif [[ $YNH_DEBIAN_VERSION == "bookworm" ]]; then
-            echo "squid";
-        fi
-        """
+    packages = "squid, mailutils"

--- a/manifest.toml
+++ b/manifest.toml
@@ -44,4 +44,10 @@ ram.runtime = "50M"
     main.exposed = "TCP"
 
     [resources.apt]
-    packages = "squid, mailutils"
+    packages = "mailutils"
+
+    # FIXME: Weird, but if we put "squid" directly among the values of `packages` above
+    # The reinstallation of the app fail. We should understand why…
+    packages_from_raw_bash = """
+        echo "squid";
+        """

--- a/scripts/remove
+++ b/scripts/remove
@@ -24,7 +24,7 @@ fi
 #=================================================
 
 # Remove a directory securely
-ynh_secure_remove --file="/etc/squid/"
+ynh_secure_remove --file="/etc/squid/squid.conf"
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

- There is no need to install squid3 anymore

## Solution

- Only install the `squid` debian package

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
